### PR TITLE
Fix markdown syntax, typo in docs

### DIFF
--- a/doc/python/creating-and-updating-figures.md
+++ b/doc/python/creating-and-updating-figures.md
@@ -613,20 +613,22 @@ There are also `for_each_xaxis()` and `for_each_yaxis()` methods that are analog
 ### Other Update Methods
 
 Figures created with the plotly.py graphing library also support:
-    - the `update_layout_images()` method in order to [update background layout images](/python/images/), 
-    - `update_annotations()` in order to [update annotations](/python/text-and-annotations/#multiple-annotations), 
-    - and `update-shapes()` in order to [update shapes](/python/shapes/).
+
+  - the `update_layout_images()` method in order to [update background layout images](/python/images/), 
+  - `update_annotations()` in order to [update annotations](/python/text-and-annotations/#multiple-annotations), 
+  - and `update_shapes()` in order to [update shapes](/python/shapes/).
 
 #### Chaining Figure Operations
 
 All of the figure update operations described above are methods that return a reference to the figure being modified. This makes it possible the chain multiple figure modification operations together into a single expression.
 
 Here is an example of a chained expression that creates:
-    - a faceted scatter plot with OLS trend lines using Plotly Express, 
-    - sets the title font size using `update_layout()`, 
-    - disables vertical grid lines using `update_xaxes()`, 
-    - updates the width and dash pattern of the trend lines using `update_traces()`, 
-    - and then displays the figure using `show()`.
+
+  - a faceted scatter plot with OLS trend lines using Plotly Express, 
+  - sets the title font size using `update_layout()`, 
+  - disables vertical grid lines using `update_xaxes()`, 
+  - updates the width and dash pattern of the trend lines using `update_traces()`, 
+  - and then displays the figure using `show()`.
 
 ```python
 import plotly.express as px


### PR DESCRIPTION
Pretty simple fix.

[This list in the docs](https://plotly.com/python/creating-and-updating-figures/#other-update-methods) doesn't render properly. This commit fixes the markdown source, and for one other list just like it.

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
